### PR TITLE
Hard refresh on orientation change

### DIFF
--- a/assets/css/section_main.css
+++ b/assets/css/section_main.css
@@ -409,6 +409,7 @@
 }
 
 .main_keyslider_plus-show .main_keyslider_plus{
+  display: block;
   transform: translate(0%,0);
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,11 @@
     // on rotation/resize
     //
     Cryptoloji.UI.handleOrientationChanges()
+    // hard refresh when orientation changes
+    Cryptoloji.stateman.on('orientationchange', function () {
+      window.location.reload()
+    })
+
 
     
     //
@@ -54,6 +59,7 @@
           .fill(EmojiList)
       }
     }, 2000)
+
     //
     // handle header show/hide
     //

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -311,6 +311,7 @@
       var orientationEvent = supportsOrientationChange ? 'orientationchange' : 'resize'
       $(window).on(orientationEvent, function (event) {
         _writeOrientationAttr()
+        Cryptoloji.stateman.emit('orientationchange')
       })
     }
   }

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -338,7 +338,10 @@
 
 
       // keyslider width
-      TweenLite.to($('.'+state+' .main_keyslider'), 0.5, {delay: 0, width: "35%"})
+      TweenLite.to($('.'+state+' .main_keyslider'), 0.5, {delay: 0, width: "35%", onComplete: function () {
+        // needed to reset element width for viewport changes
+        $('.'+state+' .main_keyslider').css('width', '')
+      }})
       // TweenLite.to($('.'+state+' .encryption_help_button > svg'), 1.25, {delay: 2.5, opacity: 1, scale: 1, ease:Elastic.easeInOut})
       TweenLite.to($('.'+state+'_help_button'), 1.25, {delay: 2.5, opacity: 1, ease:Elastic.easeInOut})
       // emoji in keyslider
@@ -464,7 +467,6 @@
     fixHeight: fixHeight,
     handleFooter: handleFooter,
     handleHeader: handleHeader,
-    handleOrientationChanges: handleOrientationChanges,
     handleOrientationChanges: handleOrientationChanges,
     loadLogicHelpButton: loadLogicHelpButton,
     selectKey: selectKey,

--- a/assets/js/ui/keyslider.js
+++ b/assets/js/ui/keyslider.js
@@ -28,7 +28,6 @@
 
     $('.keyslider', self.$element).on('scroll', function() {
       if ($('.keyslider')[0].scrollWidth - $('.keyslider')[0].offsetWidth <= $('.keyslider', self.$element).scrollLeft() + offset){
-        $('.main_keyslider_plus', self.$element).css('display', 'block')
         self.$element.addClass("main_keyslider_plus-show")
         $('.main_keyslider_plus', self.$element).css('width', keysliderMore.width + 'rem')
       }

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
             </div>
           </div>
         </div>
-        <div class="main_keyslider_plus" color-bg-main-ligther>
+        <div showItIfMobile class="main_keyslider_plus" color-bg-main-ligther>
           <div class="main_keyslider_plus_wrp" id="encryption_key_modal_open" layout="column" layout-align="center center">
             <div class="main_keyslider_spacer"></div>
             <div class="svg_wrapper svg_wrapper_plus" data-svg="assets/svg/plus.svg" color-fill-main-ligther></div>


### PR DESCRIPTION
To properly satisfy #107, we need a complete page refresh.

Currently the JS logic that handle visualization and animations are too tigh coupled with orientation assumption to properly switch without issues ( or are too low coupled and distinct ).

Thanks to the fact that we can access each state separately thanks to url fragments, we decided to opt in for a full page refresh when a orientation change is detected. Also we do not expect the users to change orientation multiple times for fun, so a full page refresh is a minor drawback for a fully-working experience